### PR TITLE
Proposal/ockham build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,24 @@ Our work is guided by the principles and conventions described in detail in the 
 
 All of these are underwritten by the **[Rules](./governance/Rules.md)** of the project.
 
+## Projects
+
+*See also [Solutions.md](./docs/Solutions.md)*
+
+Ockham.NET includes the following projects:
+
+|Solution|Repository|Description|
+|:-------|:---------|:-----|
+|Ockham.NET Build Tools|[ockham.net.build](https://github.com/ockham-net/ockham.net.build)|Shared tools for scaffolding, testing, and building Ockham.NET projects|
+
 ## The Team
+
+*See also [Team.md](./governance/Team.md)*
 
 The project is guided by the current Maintainers. Contributors are people in addition to the Maintainers who may submit proposed API changes, implementations, bugfixes, and documentation.
 
 ### Maintainers
 
-*See also [Team.md](./governance/Team.md)*
 
 |Name|Company|Location|Contact|
 |----|-------|--------|-------|

--- a/docs/Solutions.md
+++ b/docs/Solutions.md
@@ -1,0 +1,18 @@
+# Solutions
+
+This is the official list of solutions supported by the [Ockhma.NET](https://github.com/ockham-net/ockham.net) project. To propose a new solution or a new release candidate for an existing one, submit a pull request modifying this document. For further details, see **[Lifecycle](https://github.com/ockham-net/ockham.net/blob/master/governance/Lifecycle.md)**.
+
+## Released Solutions
+
+These solutions have been released for public use.
+
+|Solution|Repository|Sponsor|Version|Release Date|Docs|
+|:-------|:---------|:------|:-----:|:----------:|:---|
+
+## Proposed Solutions
+
+These solutions/revisions have been proposed and approved for development.
+
+|Solution|Repository|Sponsor|Version|Description|
+|:-------|:---------|:------|:--:|:-----|
+|Ockham.NET Build Tools|[ockham.net.build](https://github.com/ockham-net/ockham.net.build)|[Joshua Honig](https://github.com/joshua-honig)|1.0|Shared tools for scaffolding, testing, and building Ockham.NET projects|


### PR DESCRIPTION
The pull request proposes a member project called Ockham.NET Build Tools, which is a place for assembling shared tools used for scaffolding, testing, and managing other Ockham.NET projects. For example, it would be helpful to have scaffolding tools to initialize a new project as described in [Conventions](https://github.com/ockham-net/ockham.net/blob/master/governance/Conventions.md#structure), for running tests per project conventions, or publishing packages to NuGet.

For comparison, see [Arcade](https://github.com/dotnet/arcade), which is a (massive) collection of common tools used by .NET Foundation projects. I'm thinking something far smaller and simpler -- mostly just some PowerShell scripts for project scaffolding and testing.