### PR TITLE
Propose Ockham.NET.Convert module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Ockham.NET includes the following projects:
 |Solution|Repository|Description|
 |:-------|:---------|:-----|
 |Ockham.NET Build Tools|[ockham.net.build](https://github.com/ockham-net/ockham.net.build)|Shared tools for scaffolding, testing, and building Ockham.NET projects|
+|Ockham.NET.Convert|[ockham.net.convert](https://github.com/ockham-net/ockham.net.convert)|Extendable, succinct utility for converting primitive data types|
 
 ## The Team
 

--- a/docs/Solutions.md
+++ b/docs/Solutions.md
@@ -16,3 +16,4 @@ These solutions/revisions have been proposed and approved for development.
 |Solution|Repository|Sponsor|Version|Description|
 |:-------|:---------|:------|:--:|:-----|
 |Ockham.NET Build Tools|[ockham.net.build](https://github.com/ockham-net/ockham.net.build)|[Joshua Honig](https://github.com/joshua-honig)|1.0|Shared tools for scaffolding, testing, and building Ockham.NET projects|
+|Ockham.NET.Convert|[ockham.net.convert](https://github.com/ockham-net/ockham.net.convert)|[Joshua Honig](https://github.com/joshua-honig)|1.0|Extendable, succinct utility for converting primitive data types|


### PR DESCRIPTION
This formally proposes that we add the primitive data conversion utility to the Ockham project. Lots of detail can be reviewed at https://github.com/ockham-net/exp-ockham.net.convert.

It is a utility that provides a consistent data conversion API for use when loading data from external sources, such as a database or API. It uses the BCL System.Convert, IConvertible, etc. APIs where applicable, but adds handling for:

- Converting to and from `DBNull`
- Converting to `Nullable<T>`
- Converting to `enum` types, including recognizing numeric strings
- Converting to `bool` from various string representations often used in databases in the wild
- Converting to `Guid`
- Converting to `TimeSpan`

It also allows explicit instruction for:
  - Treating an empty string as null (or not)
  - Recognizing hexadecimal strings (or not)
  - Converting null values to the default value of a value type (or not)
  - Coercing *any* value to a particular target type, with or without an explicit fallback value (or not)
